### PR TITLE
Display entire Scratch stage on the Sense Hat with one block

### DIFF
--- a/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
+++ b/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
@@ -637,6 +637,8 @@ class Scratch3PiSenseHatBlocks {
 
       this._displayImageData(matrixImageData);
 
+      this.smallCtx.clearRect(0, 0, this.smallCanvas.width, this.smallCanvas.height);
+
       // Yield for a frame
       return Promise.resolve();
     }
@@ -656,6 +658,7 @@ class Scratch3PiSenseHatBlocks {
           squareSize = drawable.height;
           xOffset = (drawable.height - drawable.width) / 2;
       }
+
       const imageData = this.bigCtx.createImageData(drawable.width, drawable.height);
       imageData.data.set(drawable.data);
       this.bigCtx.putImageData(imageData, xOffset, yOffset);
@@ -665,6 +668,9 @@ class Scratch3PiSenseHatBlocks {
       const matrixImageData = this.smallCtx.getImageData(0, 0, 8, 8);
 
       this._displayImageData(matrixImageData);
+
+      this.smallCtx.clearRect(0, 0, this.smallCanvas.width, this.smallCanvas.height);
+      this.bigCtx.clearRect(0, 0, this.bigCanvas.width, this.bigCanvas.height);
 
       // Yield for a frame
       return Promise.resolve();

--- a/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
+++ b/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
@@ -31,7 +31,7 @@ class Scratch3PiSenseHatBlocks {
     static get EXTENSION_ID () {
         return 'pisensehat';
     }
-    
+
     constructor (runtime) {
         /**
          * The runtime instantiating this block package.
@@ -104,7 +104,7 @@ class Scratch3PiSenseHatBlocks {
                     opcode: 'display_stage',
                     text: formatMessage({
                         id: 'pisensehat.display_stage',
-                        default: 'display stage',
+                        default: 'display entire stage',
                         description: 'display the stage on the LED matrix'
                     }),
                     blockType: BlockType.COMMAND
@@ -610,33 +610,35 @@ class Scratch3PiSenseHatBlocks {
         fs.closeSync (fd);
     }
 
-    display_stage () {
-	     this.runtime.renderer.draw();
-       const gl = this.runtime.renderer._gl;
+    display_stage ()
+    {
+      this.runtime.renderer.draw();
+      const gl = this.runtime.renderer._gl;
 
-      	const smallWidth = 8 * (480 / 360);
-      	this.stageCtx.drawImage(gl.canvas, 60, 0, 360, 360, 0, 0, 8, 8);
-        const matrixImageData = this.stageCtx.getImageData(0, 0, 8, 8);
+      this.stageCtx.drawImage(gl.canvas, 60, 0, 360, 360, 0, 0, 8, 8);
+      const matrixImageData = this.stageCtx.getImageData(0, 0, 8, 8);
 
-        let pix = new Uint8Array (128);
-        for (count = 0; count < 64; count++)
-        {
-      	    const r = matrixImageData.data[count * 4];
-      	    const g = matrixImageData.data[(count * 4) + 1];
-      	    const b = matrixImageData.data[(count * 4) + 2];
+      let pix = new Uint8Array (128);
+      for (let count = 0; count < 64; count++)
+      {
+        const r = matrixImageData.data[count * 4];
+        const g = matrixImageData.data[(count * 4) + 1];
+        const b = matrixImageData.data[(count * 4) + 2];
 
-            const val = (Math.trunc (b / 32) * 1024) + (Math.trunc (r / 32) * 32) + Math.trunc (g / 32);
+        const val = (Math.trunc (b / 32) * 1024) + (Math.trunc (r / 32) * 32) + Math.trunc (g / 32);
 
-            const pos = this._pixel_remap (count);
-            pix[pos * 2] = val / 256;
-            pix[pos * 2 + 1] = val % 256;
-        }
+        const pos = this._pixel_remap (count);
+        pix[pos * 2] = val / 256;
+        pix[pos * 2 + 1] = val % 256;
+      }
 
-        const fd = fs.openSync (this.fbfile, "r+");
-        fs.writeSync (fd, pix, 0, 128, 0);
-        fs.closeSync (fd);
+      const fd = fs.openSync (this.fbfile, "r+");
+      fs.writeSync (fd, pix, 0, 128, 0);
+      fs.closeSync (fd);
 
-      	return Promise.resolve();
+      // Yield for a frame. Otherwise if you put this block in a forever loop,
+      // Scratch will try to run it tens of thousands of times per second.
+      return Promise.resolve();
     }
 
     _all_pixels (val)

--- a/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
+++ b/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
@@ -615,7 +615,8 @@ class Scratch3PiSenseHatBlocks {
       this.runtime.renderer.draw();
       const gl = this.runtime.renderer._gl;
 
-      this.stageCtx.drawImage(gl.canvas, 60, 0, 360, 360, 0, 0, 8, 8);
+      const xOffset = (gl.canvas.width - gl.canvas.height) / 2;
+      this.stageCtx.drawImage(gl.canvas, xOffset, 0, gl.canvas.height, gl.canvas.height, 0, 0, 8, 8);
       const matrixImageData = this.stageCtx.getImageData(0, 0, 8, 8);
 
       let pix = new Uint8Array (128);

--- a/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
+++ b/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
@@ -39,13 +39,13 @@ class Scratch3PiSenseHatBlocks {
          */
         this.runtime = runtime;
 
-      	// set up a canvas context for displaying the stage on the matrix
-      	const stageCanvas = document.createElement('canvas');
+        // set up a canvas context for displaying the stage on the matrix
+        const stageCanvas = document.createElement('canvas');
         stageCanvas.width = 480;
         stageCanvas.height = 360;
         this.stageCtx = stageCanvas.getContext('2d');
-      	this.stageCtx.imageSmoothingEnabled = true;
-      	this.stageCtx.imageSmoothingQuality = 'high';
+        this.stageCtx.imageSmoothingEnabled = true;
+        this.stageCtx.imageSmoothingQuality = 'high';
 
         // global colours
         this._fg = [255, 255, 255];
@@ -109,7 +109,7 @@ class Scratch3PiSenseHatBlocks {
                     }),
                     blockType: BlockType.COMMAND
                 },
-		            {
+                {
                     opcode: 'scroll_message',
                     text: formatMessage({
                         id: 'pisensehat.scroll_message',

--- a/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
+++ b/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
@@ -39,6 +39,14 @@ class Scratch3PiSenseHatBlocks {
          */
         this.runtime = runtime;
 
+      	// set up a canvas context for displaying the stage on the matrix
+      	const stageCanvas = document.createElement('canvas');
+        stageCanvas.width = 480;
+        stageCanvas.height = 360;
+        this.stageCtx = stageCanvas.getContext('2d');
+      	this.stageCtx.imageSmoothingEnabled = true;
+      	this.stageCtx.imageSmoothingQuality = 'high';
+
         // global colours
         this._fg = [255, 255, 255];
         this._bg = [0, 0, 0];
@@ -93,6 +101,15 @@ class Scratch3PiSenseHatBlocks {
             blockIconURI: blockIconURI,
             blocks: [
                 {
+                    opcode: 'display_stage',
+                    text: formatMessage({
+                        id: 'pisensehat.display_stage',
+                        default: 'display stage',
+                        description: 'display the stage on the LED matrix'
+                    }),
+                    blockType: BlockType.COMMAND
+                },
+		            {
                     opcode: 'scroll_message',
                     text: formatMessage({
                         id: 'pisensehat.scroll_message',
@@ -591,6 +608,35 @@ class Scratch3PiSenseHatBlocks {
         const fd = fs.openSync (this.fbfile, "r+");
         fs.writeSync (fd, pix, 0, 128, 0);
         fs.closeSync (fd);
+    }
+
+    display_stage () {
+	     this.runtime.renderer.draw();
+       const gl = this.runtime.renderer._gl;
+
+      	const smallWidth = 8 * (480 / 360);
+      	this.stageCtx.drawImage(gl.canvas, 60, 0, 360, 360, 0, 0, 8, 8);
+        const matrixImageData = this.stageCtx.getImageData(0, 0, 8, 8);
+
+        let pix = new Uint8Array (128);
+        for (count = 0; count < 64; count++)
+        {
+      	    const r = matrixImageData.data[count * 4];
+      	    const g = matrixImageData.data[(count * 4) + 1];
+      	    const b = matrixImageData.data[(count * 4) + 2];
+
+            const val = (Math.trunc (b / 32) * 1024) + (Math.trunc (r / 32) * 32) + Math.trunc (g / 32);
+
+            const pos = this._pixel_remap (count);
+            pix[pos * 2] = val / 256;
+            pix[pos * 2 + 1] = val % 256;
+        }
+
+        const fd = fs.openSync (this.fbfile, "r+");
+        fs.writeSync (fd, pix, 0, 128, 0);
+        fs.closeSync (fd);
+
+      	return Promise.resolve();
     }
 
     _all_pixels (val)

--- a/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
+++ b/node_modules/scratch-vm/src/extensions/scratch3_pisensehat/index.js
@@ -39,13 +39,20 @@ class Scratch3PiSenseHatBlocks {
          */
         this.runtime = runtime;
 
-        // set up a canvas context for displaying the stage on the matrix
-        const stageCanvas = document.createElement('canvas');
-        stageCanvas.width = 480;
-        stageCanvas.height = 360;
-        this.stageCtx = stageCanvas.getContext('2d');
-        this.stageCtx.imageSmoothingEnabled = true;
-        this.stageCtx.imageSmoothingQuality = 'high';
+        // set up canvases for scaling graphics to display on the matrix
+        this.bigCanvas = document.createElement('canvas');
+        this.bigCanvas.width = 480 * 2;
+        this.bigCanvas.height = 360 * 2;
+        this.bigCtx = this.bigCanvas.getContext('2d');
+        this.bigCtx.imageSmoothingEnabled = true;
+        this.bigCtx.imageSmoothingQuality = 'high';
+
+        this.smallCanvas = document.createElement('canvas');
+        this.smallCanvas.width = 8;
+        this.smallCanvas.height = 8;
+        this.smallCtx = this.smallCanvas.getContext('2d');
+        this.smallCtx.imageSmoothingEnabled = true;
+        this.smallCtx.imageSmoothingQuality = 'high';
 
         // global colours
         this._fg = [255, 255, 255];
@@ -101,15 +108,6 @@ class Scratch3PiSenseHatBlocks {
             blockIconURI: blockIconURI,
             blocks: [
                 {
-                    opcode: 'display_stage',
-                    text: formatMessage({
-                        id: 'pisensehat.display_stage',
-                        default: 'display entire stage',
-                        description: 'display the stage on the LED matrix'
-                    }),
-                    blockType: BlockType.COMMAND
-                },
-                {
                     opcode: 'scroll_message',
                     text: formatMessage({
                         id: 'pisensehat.scroll_message',
@@ -153,6 +151,24 @@ class Scratch3PiSenseHatBlocks {
                             defaultValue: '0110011001111110001111000011110001111110011111100011110000011000'
                         }
                     }
+                },
+                {
+                    opcode: 'display_sprite',
+                    text: formatMessage({
+                        id: 'pisensehat.display_sprite',
+                        default: 'display sprite',
+                        description: 'display the current sprite on the LED matrix'
+                    }),
+                    blockType: BlockType.COMMAND
+                },
+                {
+                    opcode: 'display_stage',
+                    text: formatMessage({
+                        id: 'pisensehat.display_stage',
+                        default: 'display stage',
+                        description: 'display the stage on the LED matrix'
+                    }),
+                    blockType: BlockType.COMMAND
                 },
                 {
                     opcode: 'all_off',
@@ -616,15 +632,51 @@ class Scratch3PiSenseHatBlocks {
       const gl = this.runtime.renderer._gl;
 
       const xOffset = (gl.canvas.width - gl.canvas.height) / 2;
-      this.stageCtx.drawImage(gl.canvas, xOffset, 0, gl.canvas.height, gl.canvas.height, 0, 0, 8, 8);
-      const matrixImageData = this.stageCtx.getImageData(0, 0, 8, 8);
+      this.smallCtx.drawImage(gl.canvas, xOffset, 0, gl.canvas.height, gl.canvas.height, 0, 0, 8, 8);
+      const matrixImageData = this.smallCtx.getImageData(0, 0, 8, 8);
 
+      this._displayImageData(matrixImageData);
+
+      // Yield for a frame
+      return Promise.resolve();
+    }
+
+    display_sprite (args, util) {
+      const drawable = this.runtime.renderer.extractDrawable(util.target.drawableID, util.target.x, util.target.y);
+      if ((drawable.width < 1) || (drawable.height < 1)) return;
+
+      // fit the sprite in a square
+      let xOffset = 0;
+      let yOffset = 0;
+      let squareSize = 0;
+      if (drawable.width > drawable.height) {
+          squareSize = drawable.width;
+          yOffset = (drawable.width - drawable.height) / 2;
+      } else {
+          squareSize = drawable.height;
+          xOffset = (drawable.height - drawable.width) / 2;
+      }
+      const imageData = this.bigCtx.createImageData(drawable.width, drawable.height);
+      imageData.data.set(drawable.data);
+      this.bigCtx.putImageData(imageData, xOffset, yOffset);
+      this.smallCtx.drawImage(this.bigCanvas,
+          0, 0, squareSize, squareSize,
+          0, 0, 8, 8);
+      const matrixImageData = this.smallCtx.getImageData(0, 0, 8, 8);
+
+      this._displayImageData(matrixImageData);
+
+      // Yield for a frame
+      return Promise.resolve();
+    }
+
+    _displayImageData (imageData) {
       let pix = new Uint8Array (128);
       for (let count = 0; count < 64; count++)
       {
-        const r = matrixImageData.data[count * 4];
-        const g = matrixImageData.data[(count * 4) + 1];
-        const b = matrixImageData.data[(count * 4) + 2];
+        const r = imageData.data[count * 4];
+        const g = imageData.data[(count * 4) + 1];
+        const b = imageData.data[(count * 4) + 2];
 
         const val = (Math.trunc (b / 32) * 1024) + (Math.trunc (r / 32) * 32) + Math.trunc (g / 32);
 
@@ -636,10 +688,6 @@ class Scratch3PiSenseHatBlocks {
       const fd = fs.openSync (this.fbfile, "r+");
       fs.writeSync (fd, pix, 0, 128, 0);
       fs.closeSync (fd);
-
-      // Yield for a frame. Otherwise if you put this block in a forever loop,
-      // Scratch will try to run it tens of thousands of times per second.
-      return Promise.resolve();
     }
 
     _all_pixels (val)


### PR DESCRIPTION
It's fun to use the Sense Hat extension to display letters, drawings, and individual pixels. But what if you could directly display the contents of the Scratch stage on the RGB Matrix, with a single block? 

I thought that would be cool, because then you could make colorful animations on the matrix using the existing tools in scratch: 
 
![pi-matrix-rainbow2-sm](https://user-images.githubusercontent.com/567844/68893868-0db56500-06f4-11ea-8b84-877352291c37.gif)

And! you can even make games that you play with the sense hat joystick (just make your sprites really big!):

![pi-matrix-pong2](https://user-images.githubusercontent.com/567844/68893875-1148ec00-06f4-11ea-9efd-a5ab943a2064.gif)

So I've added a single block, "display entire stage," that takes the currently displayed scratch stage (including any sprites, backdrops, and pen drawings that are visible), crops and scales it down to an 8x8 pixel image, and sends it to the RGB matrix. If you put this into a forever loop, and drag a sprite around on the stage, or animate it with blocks, you see it moving on the matrix.

This is just a crazy idea but I'm curious what folks think! Some open questions include:

- What should the block be called? Currently it is "display entire stage", but that isn't exactly right, because the stage is cropped to a square in order to display it on the matrix. "display stage" is good but doesn't seem _awesome_ enough. 
- Is it okay to put this block first?
- Is the performance okay? (I haven't noticed any issues)
- If you open up Scratch and click this block with the default cat showing, you can only just barely see a couple orange pixels. I wonder if there's a way to make that first experience with this block better.
